### PR TITLE
add rnaseq agg qc export

### DIFF
--- a/depmapomics/dm_omics.py
+++ b/depmapomics/dm_omics.py
@@ -195,6 +195,12 @@ async def expressionPostProcessing(
                     "format": "NumericMatrixCSV",
                     "encoding": "utf-8",
                 },
+                {
+                    "path": folder + "rna_qcs/all_qc.csv",
+                    "name": "all_samples_qc",
+                    "format": "NumericMatrixCSV",
+                    "encoding": "utf-8",
+                },
             ],
             upload_async=False,
             dataset_description=dataset_description,

--- a/depmapomics/expressions.py
+++ b/depmapomics/expressions.py
@@ -7,7 +7,7 @@ import numpy as np
 from scipy.stats import zscore
 
 from mgenepy.utils import helper as h
-from mgenepy import rna, terra
+from mgenepy import rna
 from depmapomics.qc import rna as myQC
 
 
@@ -451,6 +451,9 @@ async def postProcess(
         save=bool(save_output),
         output_path=save_output + "rna_qcs/",
     )
+
+    all_qc_df = myQC.export_qc(refworkspace, selected_samples=[]).transpose()
+    all_qc_df.to_csv(save_output + "rna_qcs/all_qc.csv")
 
     failed = failed.index.tolist()
     print("those samples completely failed qc: ", failed)

--- a/depmapomics/qc/rna.py
+++ b/depmapomics/qc/rna.py
@@ -13,8 +13,7 @@ def export_qc(
     """
     export qcs and aggregate them into one df
     """
-    if workspace is not None:
-        rnaqc = terra.getQC(workspace=workspace, only=selected_samples, qcname=colname)
+    rnaqc = terra.getQC(workspace=workspace, only=selected_samples, qcname=colname)
     if allow_missing:
         missing_qc = [k for k, v in rnaqc.items() if len(v) == 0]
         print("The following samples don't have RNAseq QC in the workspace: ")


### PR DESCRIPTION
added aggregated RNAseq QC metric table that gets uploaded to taiga latest every release. Includes all metrics and all samples, not just ones in the current release. 
The next open question would be looking at the bigger table and reevaluating the current QC standards and thresholds