### PR TITLE
SSDs not HDDs

### DIFF
--- a/RNA_pipeline/ExonUsage_hg38_fixed.wdl
+++ b/RNA_pipeline/ExonUsage_hg38_fixed.wdl
@@ -21,7 +21,7 @@ task ExonUsage {
   runtime {
     docker: "us-docker.pkg.dev/depmap-omics/public/ccle_docker_r"
     memory: "10GB"
-    disks: "local-disk 50 HDD"
+    disks: "local-disk 50 SSD"
     preemptible: "5"
   }
 }

--- a/RNA_pipeline/aggregate_vcfs.wdl
+++ b/RNA_pipeline/aggregate_vcfs.wdl
@@ -27,7 +27,7 @@ task aggregate {
         docker: "us-docker.pkg.dev/depmap-omics/public/bcftools:v1.9-1-deb_cv1"
         cpu: "${num_threads}"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         preemptible: "${num_preempt}"
     }
 

--- a/RNA_pipeline/hg38_STAR_fusion.wdl
+++ b/RNA_pipeline/hg38_STAR_fusion.wdl
@@ -45,7 +45,7 @@ task StarFusion {
     runtime {
         docker: "${docker}"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/RNA_pipeline/hg38_STAR_fusion_wdl1-0.wdl
+++ b/RNA_pipeline/hg38_STAR_fusion_wdl1-0.wdl
@@ -50,7 +50,7 @@ task StarFusion {
     runtime {
         docker: "${docker}"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/RNA_pipeline/rnaseq-germline-snps-indels.wdl
+++ b/RNA_pipeline/rnaseq-germline-snps-indels.wdl
@@ -255,7 +255,7 @@ task SplitNCigarReads {
  	}
 
     runtime {
-    	disks: "local-disk " + sub(((size(input_bam,"GB")+1)*6 + size(ref_fasta,"GB")),"\\..*","") + " HDD"
+    	disks: "local-disk " + sub(((size(input_bam,"GB")+1)*6 + size(ref_fasta,"GB")),"\\..*","") + " SSD"
 		docker: docker
 		memory: select_first([memory,16])+" GB"
     	preemptible: preemptible_count
@@ -293,7 +293,7 @@ task SplitNCigarReads_GATK4 {
         }
 
     runtime {
-        disks: "local-disk " + sub(((size(input_bam,"GB")+1)*6 + size(ref_fasta,"GB")),"\\..*","") + " HDD"
+        disks: "local-disk " + sub(((size(input_bam,"GB")+1)*6 + size(ref_fasta,"GB")),"\\..*","") + " SSD"
         docker: docker
         memory: select_first([memory,16])+" GB"
         preemptible: preemptible_count
@@ -341,7 +341,7 @@ task BaseRecalibrator {
 
     runtime {
         memory: select_first([memory,16])+" GB"
-        disks: "local-disk " + sub((size(input_bam,"GB")*3)+100, "\\..*", "") + " HDD"
+        disks: "local-disk " + sub((size(input_bam,"GB")*3)+100, "\\..*", "") + " SSD"
         docker: docker
         preemptible: preemptible_count
     }
@@ -384,7 +384,7 @@ task ApplyBQSR {
 
     runtime {
         memory: select_first([memory,16])+" GB"
-        disks: "local-disk 300 HDD"
+        disks: "local-disk 300 SSD"
         preemptible: preemptible_count
         docker: docker
     }
@@ -431,7 +431,7 @@ task HaplotypeCaller {
 	runtime {
 		docker: docker
 		memory: select_first([memory,6])+" GB"
-		disks: "local-disk " + sub((size(input_bam,"GB")*2)+100, "\\..*", "") + " HDD"
+		disks: "local-disk " + sub((size(input_bam,"GB")*2)+100, "\\..*", "") + " SSD"
 		preemptible: preemptible_count
 	}
 }
@@ -480,7 +480,7 @@ task HaplotypeCaller_GATK4 {
 	runtime {
 		docker: docker
 		memory: select_first([memory,10])+" GB"
-		disks: "local-disk " + sub((size(input_bam,"GB")*2)+100, "\\..*", "") + " HDD"
+		disks: "local-disk " + sub((size(input_bam,"GB")*2)+100, "\\..*", "") + " SSD"
 		preemptible: preemptible_count
 	}
 }
@@ -523,7 +523,7 @@ task VariantFiltration {
 		docker: docker
         bootDiskSizeGb: "32"
 		memory: select_first([memory,6])+" GB"
-		disks: "local-disk " + sub((size(input_vcf,"GB")*3)+180, "\\..*", "") + " HDD"
+		disks: "local-disk " + sub((size(input_vcf,"GB")*3)+180, "\\..*", "") + " SSD"
 		preemptible: preemptible_count
 	}
 }
@@ -557,7 +557,7 @@ task MergeVCFs {
 
     runtime {
         memory: select_first([memory,6])+" GB"
-        disks: "local-disk " + disk_size + " HDD"
+        disks: "local-disk " + disk_size + " SSD"
         docker: docker
         preemptible: preemptible_count
     }
@@ -602,7 +602,7 @@ task ScatterIntervalList {
     }
 
     runtime {
-        disks: "local-disk 1 HDD"
+        disks: "local-disk 1 SSD"
         memory: select_first([memory,4])+" GB"
         docker: docker
         preemptible: preemptible_count
@@ -651,7 +651,7 @@ task ScatterIntervalList_GATK4 {
     }
 
     runtime {
-        disks: "local-disk 1 HDD"
+        disks: "local-disk 1 SSD"
         memory: select_first([memory,4])+" GB"
         docker: docker
         preemptible: preemptible_count
@@ -685,7 +685,7 @@ task RevertSam {
 
     runtime {
         docker: docker
-        disks: "local-disk " + sub(((size(input_bam,"GB")+1)*5),"\\..*","") + " HDD"
+        disks: "local-disk " + sub(((size(input_bam,"GB")+1)*5),"\\..*","") + " SSD"
         memory: "8 GB"
         preemptible: preemptible_count
     }

--- a/RNA_pipeline/rnaseq_mutect2_tumor_only.wdl
+++ b/RNA_pipeline/rnaseq_mutect2_tumor_only.wdl
@@ -394,7 +394,7 @@ task SplitNCigarReads_GATK4 {
   }
 
   runtime {
-    disks: "local-disk "+select_first([disk,200])+" HDD"
+    disks: "local-disk "+select_first([disk,200])+" SSD"
     docker: docker
     memory: select_first([memory,16])+" GB"
     preemptible: select_first([preemptible_count, 10])
@@ -445,7 +445,7 @@ task BaseRecalibrator {
 
   runtime {
     memory: select_first([memory,16])+" GB"
-    disks: "local-disk "+ select_first([disk,200])+" HDD"
+    disks: "local-disk "+ select_first([disk,200])+" SSD"
     docker: docker
     preemptible: select_first([preemptible_count, 10])
   }
@@ -491,7 +491,7 @@ task ApplyBQSR {
 
   runtime {
     memory: select_first([memory,16])+" GB"
-    disks: "local-disk 300 HDD"
+    disks: "local-disk 300 SSD"
     preemptible: select_first([preemptible_count, 10])
     docker: docker
   }
@@ -531,7 +531,7 @@ task MergeVCFs {
 
   runtime {
     memory: select_first([memory,6])+" GB"
-    disks: "local-disk " + disk_size + " HDD"
+    disks: "local-disk " + disk_size + " SSD"
     docker: docker
     preemptible: select_first([preemptible_count, 10])
   }
@@ -580,7 +580,7 @@ task ScatterIntervalList_GATK4 {
   }
 
   runtime {
-    disks: "local-disk 1 HDD"
+    disks: "local-disk 1 SSD"
     memory: select_first([memory,4])+" GB"
     docker: docker
     preemptible: select_first([preemptible_count, 10])
@@ -620,7 +620,7 @@ task RevertSam {
 
   runtime {
     docker: docker
-    disks: "local-disk "+select_first([disk,200])+" HDD"
+    disks: "local-disk "+select_first([disk,200])+" SSD"
     memory: "8 GB"
     preemptible: select_first([preemptible_count, 10])
   }
@@ -661,7 +661,7 @@ task M2 {
     Int? max_retries
     Int? disk_space
     Int? cpu
-    Boolean use_ssd = false
+    Boolean use_ssd = true
   }
 
   String output_vcf = "output" + if compress then ".vcf.gz" else ".vcf"
@@ -759,7 +759,7 @@ task M2 {
     docker: gatk_docker
     bootDiskSizeGb: 12
     memory: machine_mem + " MB"
-    disks: "local-disk " + select_first([disk_space, 100]) + if use_ssd then " SSD" else " HDD"
+    disks: "local-disk " + select_first([disk_space, 100]) + if use_ssd then " SSD" else " SSD"
     preemptible: select_first([preemptible, 10])
     maxRetries: select_first([max_retries, 0])
     cpu: select_first([cpu, 1])
@@ -796,7 +796,7 @@ task MergeStats {
     docker: runtime_params.gatk_docker
     bootDiskSizeGb: runtime_params.boot_disk_size
     memory: runtime_params.machine_mem + " MB"
-    disks: "local-disk " + runtime_params.disk + " HDD"
+    disks: "local-disk " + runtime_params.disk + " SSD"
     preemptible: runtime_params.preemptible
     maxRetries: runtime_params.max_retries
     cpu: runtime_params.cpu
@@ -856,7 +856,7 @@ task Filter {
     docker: runtime_params.gatk_docker
     bootDiskSizeGb: runtime_params.boot_disk_size
     memory: runtime_params.machine_mem + " MB"
-    disks: "local-disk " + select_first([disk_space, runtime_params.disk]) + " HDD"
+    disks: "local-disk " + select_first([disk_space, runtime_params.disk]) + " SSD"
     preemptible: runtime_params.preemptible
     maxRetries: runtime_params.max_retries
     cpu: runtime_params.cpu
@@ -991,7 +991,7 @@ task Funcotate {
     docker: runtime_params.gatk_docker
     bootDiskSizeGb: runtime_params.boot_disk_size
     memory: runtime_params.machine_mem + " MB"
-    disks: "local-disk " + select_first([disk_space, runtime_params.disk]) + " HDD"
+    disks: "local-disk " + select_first([disk_space, runtime_params.disk]) + " SSD"
     preemptible: runtime_params.preemptible
     maxRetries: runtime_params.max_retries
     cpu: runtime_params.cpu
@@ -1045,7 +1045,7 @@ task VariantFiltration {
     docker: docker
     bootDiskSizeGb: "32"
     memory: select_first([memory,6])+" GB"
-    disks: "local-disk "+select_first([disk, 250])+" HDD"
+    disks: "local-disk "+select_first([disk, 250])+" SSD"
     preemptible: select_first([preemptible_count, 10])
   }
 }
@@ -1109,7 +1109,7 @@ task picard_CleanAfterStar {
     docker: docker
     bootDiskSizeGb: "32"
     memory: select_first([memory,6])+" GB"
-    disks: "local-disk "+select_first([disk, 250])+" HDD"
+    disks: "local-disk "+select_first([disk, 250])+" SSD"
     preemptible: select_first([preemptible_count, 10])
   }
 }

--- a/RNA_pipeline/rnaseqc2_v1-0_BETA_cfg.wdl
+++ b/RNA_pipeline/rnaseqc2_v1-0_BETA_cfg.wdl
@@ -33,7 +33,7 @@ task rnaseqc2 {
     runtime {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/RNA_pipeline/rnaseqc2_wdl1-0.wdl
+++ b/RNA_pipeline/rnaseqc2_wdl1-0.wdl
@@ -37,7 +37,7 @@ task rnaseqc2 {
     runtime {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/RNA_pipeline/rsem_aggregate_results.wdl
+++ b/RNA_pipeline/rsem_aggregate_results.wdl
@@ -70,7 +70,7 @@ task rsem_aggregate_results {
 	runtime {
 		docker: "docker.io/jkobject/ccle_rnaseq:latest"
 		memory: "${memory}GB"
-		disks: "local-disk ${disk_space} HDD"
+		disks: "local-disk ${disk_space} SSD"
 		cpu: "${num_threads}"
 		preemptible: "${num_preempt}"
 	}

--- a/RNA_pipeline/rsem_depmap.wdl
+++ b/RNA_pipeline/rsem_depmap.wdl
@@ -49,7 +49,7 @@ task rsem {
     runtime {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/RNA_pipeline/rsem_v1-0_BETA_cfg.wdl
+++ b/RNA_pipeline/rsem_v1-0_BETA_cfg.wdl
@@ -37,7 +37,7 @@ task rsem {
     runtime {
         docker: "us-docker.pkg.dev/depmap-omics/public/gtex-rnaseq:V10"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/RNA_pipeline/samtofastq_v1-0_BETA_cfg.wdl
+++ b/RNA_pipeline/samtofastq_v1-0_BETA_cfg.wdl
@@ -32,7 +32,7 @@ task samtofastq {
     runtime {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/RNA_pipeline/samtofastq_wdl1-0.wdl
+++ b/RNA_pipeline/samtofastq_wdl1-0.wdl
@@ -36,7 +36,7 @@ task samtofastq {
     runtime {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/RNA_pipeline/star_v1-0_BETA_cfg.wdl
+++ b/RNA_pipeline/star_v1-0_BETA_cfg.wdl
@@ -123,7 +123,7 @@ task star {
     runtime {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/RNA_pipeline/star_v1-0_BETA_cfg_hg19.wdl
+++ b/RNA_pipeline/star_v1-0_BETA_cfg_hg19.wdl
@@ -123,7 +123,7 @@ task star {
     runtime {
         docker: "us-docker.pkg.dev/depmap-omics/public/gtex-rnaseq:V9"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/RNA_pipeline/star_wdl1-0.wdl
+++ b/RNA_pipeline/star_wdl1-0.wdl
@@ -127,7 +127,7 @@ task star {
     runtime {
         docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/WGS_pipeline/Aggregate_CN_seg_files.wdl
+++ b/WGS_pipeline/Aggregate_CN_seg_files.wdl
@@ -24,7 +24,7 @@ task aggregate_CN_segments {
     runtime {
         docker: "flyingrobin/cds_shiny"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         preemptible: "${num_preempt}"
     }
 

--- a/WGS_pipeline/BamToUnmappedRGBams_noHardClips.wdl
+++ b/WGS_pipeline/BamToUnmappedRGBams_noHardClips.wdl
@@ -92,7 +92,7 @@ task RevertSam {
   }
   runtime {
     docker: docker
-    disks: "local-disk " + disk_size + " HDD"
+    disks: "local-disk " + disk_size + " SSD"
     memory: machine_mem_gb + " GB"
     preemptible: preemptible_attempts
   }
@@ -125,7 +125,7 @@ task SortSam {
   }
   runtime {
     docker: docker
-    disks: "local-disk " + disk_size + " HDD"
+    disks: "local-disk " + disk_size + " SSD"
     memory: machine_mem_gb + " GB"
     preemptible: preemptible_attempts
   }

--- a/WGS_pipeline/CNV_Somatic_Workflow_on_Sample.wdl
+++ b/WGS_pipeline/CNV_Somatic_Workflow_on_Sample.wdl
@@ -30,7 +30,7 @@
 #############
 
 import "https://raw.githubusercontent.com/gatk-workflows/gatk4-somatic-cnvs/1.3.0/cnv_common_tasks.wdl" as CNVTasks
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-somatic-cnvs/1.3.0/cnv_somatic_oncotator_workflow.wdl" as CNVOncotator
+import "https://gist.githubusercontent.com/cds-github-apps/167613785407905d2590ac51b6670895/raw/b362c980e41b49b2b3d1b1b36b8b3788fe6c3e93/cnv_somatic_oncotator_workflow.wdl" as CNVOncotator
 
 workflow CNVSomaticPairWorkflow {
 
@@ -159,7 +159,8 @@ workflow CNVSomaticPairWorkflow {
             gatk_docker = gatk_docker,
             mem_gb = mem_gb_for_preprocess_intervals,
             disk_space_gb = preprocess_intervals_disk,
-            preemptible_attempts = preemptible_attempts
+            preemptible_attempts = preemptible_attempts,
+            use_ssd = true
     }
 
     Int collect_counts_tumor_disk = tumor_bam_size + ceil(size(PreprocessIntervals.preprocessed_intervals, "GB")) + disk_pad
@@ -176,7 +177,8 @@ workflow CNVSomaticPairWorkflow {
             gatk_docker = gatk_docker,
             mem_gb = mem_gb_for_collect_counts,
             disk_space_gb = collect_counts_tumor_disk,
-            preemptible_attempts = preemptible_attempts
+            preemptible_attempts = preemptible_attempts,
+            use_ssd = true
     }
 
     Int collect_allelic_counts_tumor_disk = tumor_bam_size + ref_size + disk_pad
@@ -193,7 +195,8 @@ workflow CNVSomaticPairWorkflow {
             gatk_docker = gatk_docker,
             mem_gb = mem_gb_for_collect_allelic_counts,
             disk_space_gb = collect_allelic_counts_tumor_disk,
-            preemptible_attempts = preemptible_attempts
+            preemptible_attempts = preemptible_attempts,
+            use_ssd = true
     }
 
     Int denoise_read_counts_tumor_disk = read_count_pon_size + ceil(size(CollectCountsTumor.counts, "GB")) + disk_pad
@@ -307,7 +310,8 @@ workflow CNVSomaticPairWorkflow {
                 gatk_docker = gatk_docker,
                 mem_gb = mem_gb_for_collect_counts,
                 disk_space_gb = collect_counts_normal_disk,
-                preemptible_attempts = preemptible_attempts
+                preemptible_attempts = preemptible_attempts,
+                use_ssd = true
         }
 
         Int collect_allelic_counts_normal_disk = normal_bam_size + ref_size + disk_pad
@@ -324,7 +328,8 @@ workflow CNVSomaticPairWorkflow {
                 gatk_docker = gatk_docker,
                 mem_gb = mem_gb_for_collect_allelic_counts,
                 disk_space_gb = collect_allelic_counts_normal_disk,
-                preemptible_attempts = preemptible_attempts
+                preemptible_attempts = preemptible_attempts,
+                use_ssd = true
         }
 
         Int denoise_read_counts_normal_disk = read_count_pon_size + ceil(size(CollectCountsNormal.counts, "GB")) + disk_pad

--- a/WGS_pipeline/CNV_Somatic_Workflow_on_Sample.wdl
+++ b/WGS_pipeline/CNV_Somatic_Workflow_on_Sample.wdl
@@ -514,7 +514,7 @@ task DenoiseReadCounts {
     String gatk_docker
     Int? mem_gb
     Int? disk_space_gb
-    Boolean use_ssd = false
+    Boolean use_ssd = true
     Int? cpu
     Int? preemptible_attempts
 
@@ -579,7 +579,7 @@ task ModelSegments {
     String gatk_docker
     Int? mem_gb
     Int? disk_space_gb
-    Boolean use_ssd = false
+    Boolean use_ssd = true
     Int? cpu
     Int? preemptible_attempts
 
@@ -667,7 +667,7 @@ task CallCopyRatioSegments {
     String gatk_docker
     Int? mem_gb
     Int? disk_space_gb
-    Boolean use_ssd = false
+    Boolean use_ssd = true
     Int? cpu
     Int? preemptible_attempts
 
@@ -714,7 +714,7 @@ task PlotDenoisedCopyRatios {
     String gatk_docker
     Int? mem_gb
     Int? disk_space_gb
-    Boolean use_ssd = false
+    Boolean use_ssd = true
     Int? cpu
     Int? preemptible_attempts
 
@@ -773,7 +773,7 @@ task PlotModeledSegments {
     String gatk_docker
     Int? mem_gb
     Int? disk_space_gb
-    Boolean use_ssd = false
+    Boolean use_ssd = true
     Int? cpu
     Int? preemptible_attempts
 

--- a/WGS_pipeline/CramToBam.wdl
+++ b/WGS_pipeline/CramToBam.wdl
@@ -115,7 +115,7 @@ task RunCramToBam {
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
-    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " SSD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
     docker: samtools_docker
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])
@@ -182,7 +182,7 @@ task RunCramToBamRequesterPays {
   runtime {
     cpu: select_first([runtime_attr.cpu_cores, default_attr.cpu_cores])
     memory: select_first([runtime_attr.mem_gb, default_attr.mem_gb]) + " GiB"
-    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " HDD"
+    disks: "local-disk " + select_first([runtime_attr.disk_gb, default_attr.disk_gb]) + " SSD"
     bootDiskSizeGb: select_first([runtime_attr.boot_disk_gb, default_attr.boot_disk_gb])
     docker: samtools_docker
     preemptible: select_first([runtime_attr.preemptible_tries, default_attr.preemptible_tries])

--- a/WGS_pipeline/Manta_SomaticSV.wdl
+++ b/WGS_pipeline/Manta_SomaticSV.wdl
@@ -71,7 +71,7 @@ task Manta {
         docker: "${manta_docker}"
         memory: select_first([mem_size, 100]) + " GB"
         cpu: select_first([cpu_num, 32])
-        disks: "local-disk " + select_first([disk_size, 200]) + " HDD"
+        disks: "local-disk " + select_first([disk_size, 200]) + " SSD"
         preemptible: select_first([preemptible_attempts, 3])
     }
     output {

--- a/WGS_pipeline/PreProcessingForVariantDiscovery_GATK4.wdl
+++ b/WGS_pipeline/PreProcessingForVariantDiscovery_GATK4.wdl
@@ -325,7 +325,7 @@ task SamToFastqAndBwaMem {
     docker: docker_image
     memory: mem_size
     cpu: num_cpu
-    disks: "local-disk " + disk_size + " HDD"
+    disks: "local-disk " + disk_size + " SSD"
   }
   output {
     File output_bam = "${output_bam_basename}.bam"
@@ -386,7 +386,7 @@ task MergeBamAlignment {
     preemptible: preemptible_tries
     docker: docker_image
     memory: mem_size
-    disks: "local-disk " + disk_size + " HDD"
+    disks: "local-disk " + disk_size + " SSD"
   }
   output {
     File output_bam = "${output_bam_basename}.bam"
@@ -434,7 +434,7 @@ task SortAndFixTags {
     preemptible: preemptible_tries
     docker: docker_image
     memory: mem_size
-    disks: "local-disk " + disk_size + " HDD"
+    disks: "local-disk " + disk_size + " SSD"
   }
   output {
     File output_bam = "${output_bam_basename}.bam"
@@ -476,7 +476,7 @@ task MarkDuplicates {
     preemptible: preemptible_tries
     docker: docker_image
     memory: mem_size
-    disks: "local-disk " + disk_size + " HDD"
+    disks: "local-disk " + disk_size + " SSD"
   }
   output {
     File output_bam = "${output_bam_basename}.bam"
@@ -580,7 +580,7 @@ task BaseRecalibrator {
     preemptible: preemptible_tries
     docker: docker_image
     memory: mem_size
-    disks: "local-disk " + disk_size + " HDD"
+    disks: "local-disk " + disk_size + " SSD"
   }
   output {
     File recalibration_report = "${recalibration_report_filename}"
@@ -611,7 +611,7 @@ task GatherBqsrReports {
     preemptible: preemptible_tries
     docker: docker_image
     memory: mem_size
-    disks: "local-disk " + disk_size + " HDD"
+    disks: "local-disk " + disk_size + " SSD"
   }
   output {
     File output_bqsr_report = "${output_report_filename}"
@@ -654,7 +654,7 @@ task ApplyBQSR {
     preemptible: preemptible_tries
     docker: docker_image
     memory: mem_size
-    disks: "local-disk " + disk_size + " HDD"
+    disks: "local-disk " + disk_size + " SSD"
   }
   output {
     File recalibrated_bam = "${output_bam_basename}.bam"
@@ -687,7 +687,7 @@ task GatherBamFiles {
     preemptible: preemptible_tries
     docker: docker_image
     memory: mem_size
-    disks: "local-disk " + disk_size + " HDD"
+    disks: "local-disk " + disk_size + " SSD"
   }
   output {
     File output_bam = "${output_bam_basename}.bam"

--- a/WGS_pipeline/PureCN.wdl
+++ b/WGS_pipeline/PureCN.wdl
@@ -77,7 +77,7 @@ task PureCN {
 	runtime {
 		docker: "markusriester/purecn:2.2.0"
 		bootDiskSizeGb: 32
-		disks: "local-disk ${hardware_disk_size_GB} HDD"
+		disks: "local-disk ${hardware_disk_size_GB} SSD"
 		memory: "${hardware_memory_GB} GB"
 		cpu: "${num_threads}"
 		continueOnReturnCode: true

--- a/WGS_pipeline/PureCN_pipeline/PureCN.wdl
+++ b/WGS_pipeline/PureCN_pipeline/PureCN.wdl
@@ -79,7 +79,7 @@ task PureCN {
 	runtime {
 		docker: purecn_docker
 		bootDiskSizeGb: 32
-		disks: "local-disk ${hardware_disk_size_GB} HDD"
+		disks: "local-disk ${hardware_disk_size_GB} SSD"
 		memory: "${hardware_memory_GB} GB"
 		cpu: "${num_threads}"
 		continueOnReturnCode: true

--- a/WGS_pipeline/PureCN_pipeline/PureCN_update_solution.wdl
+++ b/WGS_pipeline/PureCN_pipeline/PureCN_update_solution.wdl
@@ -48,7 +48,7 @@ task run_update_solution {
   runtime {
 	docker: purecn_docker
 	bootDiskSizeGb: 32
-	disks: "local-disk ${hardware_disk_size_GB} HDD"
+	disks: "local-disk ${hardware_disk_size_GB} SSD"
 	memory: "${hardware_memory_GB}GB"
 	cpu: 1
 	continueOnReturnCode: true

--- a/WGS_pipeline/WGS_preprocessing.wdl
+++ b/WGS_pipeline/WGS_preprocessing.wdl
@@ -1,8 +1,8 @@
 version 1.0
 # converts hg19 bams to hg38, and preprocesses it for the following steps (WGS_pipeline)
 import "CramToBam.wdl" as CramToBam
-import "https://raw.githubusercontent.com/gatk-workflows/seq-format-conversion/3.0.0/bam-to-unmapped-bams.wdl" as BamToUnmappedRGBams
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-data-processing/2.1.1/processing-for-variant-discovery-gatk4.wdl" as PreProcessingForVariantDiscovery_GATK4
+import "https://gist.githubusercontent.com/cds-github-apps/167613785407905d2590ac51b6670895/raw/e6c994be33c227d48cc81d815006eb5965605646/bam-to-unmapped-bams.wdl" as BamToUnmappedRGBams
+import "https://gist.githubusercontent.com/cds-github-apps/167613785407905d2590ac51b6670895/raw/e6c994be33c227d48cc81d815006eb5965605646/processing-for-variant-discovery-gatk4.wdl" as PreProcessingForVariantDiscovery_GATK4
 import "ArrayOfFilesToTxt_v1_0.wdl" as ArrayOfFilesToTxt
 
 workflow WGS_preprocessing {

--- a/WGS_pipeline/WGS_preprocessing_DRAGEN_24Q2.wdl
+++ b/WGS_pipeline/WGS_preprocessing_DRAGEN_24Q2.wdl
@@ -3,7 +3,7 @@ version 1.0
 # for DRAGEN-aligned cram samples
 import "CramToBam.wdl" as CramToBam
 import "BamToUnmappedRGBams_noHardClips.wdl" as BamToUnmappedRGBams
-import "https://raw.githubusercontent.com/gatk-workflows/gatk4-data-processing/2.1.1/processing-for-variant-discovery-gatk4.wdl" as PreProcessingForVariantDiscovery_GATK4
+import "https://gist.githubusercontent.com/cds-github-apps/167613785407905d2590ac51b6670895/raw/e6c994be33c227d48cc81d815006eb5965605646/processing-for-variant-discovery-gatk4.wdl" as PreProcessingForVariantDiscovery_GATK4
 import "ArrayOfFilesToTxt_v1_0.wdl" as ArrayOfFilesToTxt
 
 workflow WGS_preprocessing {

--- a/WGS_pipeline/aggregate_microsatellite_repeats.wdl
+++ b/WGS_pipeline/aggregate_microsatellite_repeats.wdl
@@ -53,7 +53,7 @@ task find_n_repeats {
         docker: "iboylebroad/microsat:latest"
         cpu: "${num_threads}"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         preemptible: "${num_preempt}"
     }
 

--- a/WGS_pipeline/bcftools.wdl
+++ b/WGS_pipeline/bcftools.wdl
@@ -55,7 +55,7 @@ task bcftools_fix_ploidy {
         docker: docker
         bootDiskSizeGb: "${boot_disk_size}"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/WGS_pipeline/cnn-variant-common-tasks.wdl
+++ b/WGS_pipeline/cnn-variant-common-tasks.wdl
@@ -58,7 +58,7 @@ command <<<
   runtime {
     docker: "${gatk_docker}"
     memory: machine_mem + " MB"
-    disks: "local-disk " + select_first([disk_space_gb, default_disk_space_gb]) + " HDD"
+    disks: "local-disk " + select_first([disk_space_gb, default_disk_space_gb]) + " SSD"
     preemptible: select_first([preemptible_attempts, 3])
     cpu: select_first([cpu, 1])
     zones: "us-central1-b" # Needs to be a zone that guarantees CPUs with AVX see (https://cloud.google.com/compute/docs/regions-zones/)
@@ -120,8 +120,8 @@ task RunHC4 {
     runtime {
         docker: "${gatk_docker}"
         memory: machine_mem + " MB"
-        # Note that the space before SSD and HDD should be included.
-        disks: "local-disk " + sub(disk_space_gb, "\\..*", "") + " HDD"
+        # Note that the space before SSD should be included.
+        disks: "local-disk " + sub(disk_space_gb, "\\..*", "") + " SSD"
         preemptible: select_first([preemptible_attempts, 3])
         cpu: select_first([cpu, 1])
         bootDiskSizeGb: "16"
@@ -177,8 +177,8 @@ command <<<
   runtime {
     docker: "${gatk_docker}"
     memory: machine_mem + " MB"
-    # Note that the space before HDD and HDD should be included.
-    disks: "local-disk " + select_first([disk_space_gb, default_disk_space_gb]) + " HDD"
+    # Note that the space before SSD should be included.
+    disks: "local-disk " + select_first([disk_space_gb, default_disk_space_gb]) + " SSD"
     preemptible: select_first([preemptible_attempts, 3])
     cpu: select_first([cpu, 1])
     bootDiskSizeGb: "16"
@@ -228,7 +228,7 @@ task SplitIntervals {
     runtime {
         docker: "${gatk_docker}"
         memory: machine_mem + " MB"
-        disks: "local-disk " + select_first([disk_space, 100]) + " HDD"
+        disks: "local-disk " + select_first([disk_space, 100]) + " SSD"
         preemptible: select_first([preemptible_attempts, 10])
         cpu: select_first([cpu, 1])
         bootDiskSizeGb: "16"
@@ -270,7 +270,7 @@ task MergeVCFs {
     runtime {
         docker: "${gatk_docker}"
         memory: machine_mem + " MB"
-        disks: "local-disk " + select_first([disk_space_gb, default_disk_space_gb]) + " HDD"
+        disks: "local-disk " + select_first([disk_space_gb, default_disk_space_gb]) + " SSD"
         preemptible: select_first([preemptible_attempts, 10])
         cpu: select_first([cpu, 1])
         bootDiskSizeGb: "16"
@@ -324,8 +324,8 @@ command <<<
     docker: "broadinstitute/genomes-in-the-cloud:2.1.1"
     memory: machine_mem + " MB"
 
-    # Note that the space before SSD and HDD should be included.
-    disks: "local-disk " + disk_space_gb + " HDD"
+    # Note that the space before SSD should be included.
+    disks: "local-disk " + disk_space_gb + " SSD"
     preemptible: select_first([preemptible_attempts, 3])
     cpu: select_first([cpu, 1])
   }
@@ -353,6 +353,6 @@ task SamtoolsMergeBAMs {
   runtime {
     docker: "broadinstitute/genomes-in-the-cloud:2.1.1"
     memory: "16 GB"
-    disks: "local-disk " + disk_space_gb + " HDD"
+    disks: "local-disk " + disk_space_gb + " SSD"
   }
 }

--- a/WGS_pipeline/cnn-variant-filter.wdl
+++ b/WGS_pipeline/cnn-variant-filter.wdl
@@ -10,7 +10,7 @@
 # (https://github.com/gatk-workflows/gatk4-data-processing/blob/master/processing-for-variant-discovery-gatk4.wdl)
 # Also accepts a BAM as the input file in which case a BAM index is required as well.
 
-import "https://raw.githubusercontent.com/broadinstitute/ccle_processing/master/WGS_pipeline/cnn-variant-common-tasks.wdl" as CNNTasks
+import "https://gist.githubusercontent.com/cds-github-apps/167613785407905d2590ac51b6670895/raw/d1f9f2a16c5c6119ea57b18f453779ee8c72f012/cnn-variant-common-tasks.wdl" as CNNTasks
 
 workflow Cram2FilteredVcf {
     File input_file                  # Aligned CRAM file or Aligned BAM files

--- a/WGS_pipeline/cnv_somatic_pair_workflow.wdl
+++ b/WGS_pipeline/cnv_somatic_pair_workflow.wdl
@@ -556,7 +556,7 @@ task DenoiseReadCounts {
       String gatk_docker
       Int? mem_gb
       Int? disk_space_gb
-      Boolean use_ssd = false
+      Boolean use_ssd = true
       Int? cpu
       Int? preemptible_attempts
     }
@@ -623,7 +623,7 @@ task ModelSegments {
       String gatk_docker
       Int? mem_gb
       Int? disk_space_gb
-      Boolean use_ssd = false
+      Boolean use_ssd = true
       Int? cpu
       Int? preemptible_attempts
     }
@@ -713,7 +713,7 @@ task CallCopyRatioSegments {
       String gatk_docker
       Int? mem_gb
       Int? disk_space_gb
-      Boolean use_ssd = false
+      Boolean use_ssd = true
       Int? cpu
       Int? preemptible_attempts
     }
@@ -762,7 +762,7 @@ task PlotDenoisedCopyRatios {
       String gatk_docker
       Int? mem_gb
       Int? disk_space_gb
-      Boolean use_ssd = false
+      Boolean use_ssd = true
       Int? cpu
       Int? preemptible_attempts
     }
@@ -822,7 +822,7 @@ task PlotModeledSegments {
       String gatk_docker
       Int? mem_gb
       Int? disk_space_gb
-      Boolean use_ssd = false
+      Boolean use_ssd = true
       Int? cpu
       Int? preemptible_attempts
     }

--- a/WGS_pipeline/cnv_somatic_pair_workflow.wdl
+++ b/WGS_pipeline/cnv_somatic_pair_workflow.wdl
@@ -38,7 +38,7 @@
 version 1.0
 
 import "https://raw.githubusercontent.com/broadinstitute/gatk/4.2.6.1/scripts/cnv_wdl/cnv_common_tasks.wdl" as CNVTasks
-import "https://raw.githubusercontent.com/broadinstitute/gatk/4.2.6.1/scripts/cnv_wdl/somatic/cnv_somatic_funcotate_seg_workflow.wdl" as CNVFuncotateSegments
+import "https://gist.githubusercontent.com/cds-github-apps/167613785407905d2590ac51b6670895/raw/b362c980e41b49b2b3d1b1b36b8b3788fe6c3e93/cnv_somatic_oncotator_workflow.wdl" as CNVFuncotateSegments
 
 workflow CNVSomaticPairWorkflow {
 
@@ -182,7 +182,8 @@ workflow CNVSomaticPairWorkflow {
             gatk_docker = gatk_docker,
             mem_gb = mem_gb_for_preprocess_intervals,
             disk_space_gb = preprocess_intervals_disk,
-            preemptible_attempts = preemptible_attempts
+            preemptible_attempts = preemptible_attempts,
+            use_ssd = true
     }
 
     Int collect_counts_tumor_disk = tumor_bam_size + ceil(size(PreprocessIntervals.preprocessed_intervals, "GB")) + disk_pad
@@ -201,7 +202,8 @@ workflow CNVSomaticPairWorkflow {
             mem_gb = mem_gb_for_collect_counts,
             disk_space_gb = collect_counts_tumor_disk,
             preemptible_attempts = preemptible_attempts,
-            gcs_project_for_requester_pays = gcs_project_for_requester_pays
+            gcs_project_for_requester_pays = gcs_project_for_requester_pays,
+            use_ssd = true
     }
 
     Int collect_allelic_counts_tumor_disk = tumor_bam_size + ref_size + disk_pad
@@ -219,7 +221,8 @@ workflow CNVSomaticPairWorkflow {
             mem_gb = mem_gb_for_collect_allelic_counts,
             disk_space_gb = collect_allelic_counts_tumor_disk,
             preemptible_attempts = preemptible_attempts,
-            gcs_project_for_requester_pays = gcs_project_for_requester_pays
+            gcs_project_for_requester_pays = gcs_project_for_requester_pays,
+            use_ssd = true
     }
 
     Int denoise_read_counts_tumor_disk = read_count_pon_size + ceil(size(CollectCountsTumor.counts, "GB")) + disk_pad
@@ -335,7 +338,8 @@ workflow CNVSomaticPairWorkflow {
                 mem_gb = mem_gb_for_collect_counts,
                 disk_space_gb = collect_counts_normal_disk,
                 preemptible_attempts = preemptible_attempts,
-                gcs_project_for_requester_pays = gcs_project_for_requester_pays
+                gcs_project_for_requester_pays = gcs_project_for_requester_pays,
+                use_ssd = true
         }
 
         Int collect_allelic_counts_normal_disk = normal_bam_size + ref_size + disk_pad
@@ -353,7 +357,8 @@ workflow CNVSomaticPairWorkflow {
                 mem_gb = mem_gb_for_collect_allelic_counts,
                 disk_space_gb = collect_allelic_counts_normal_disk,
                 preemptible_attempts = preemptible_attempts,
-                gcs_project_for_requester_pays = gcs_project_for_requester_pays
+                gcs_project_for_requester_pays = gcs_project_for_requester_pays,
+                use_ssd = true
         }
 
         Int denoise_read_counts_normal_disk = read_count_pon_size + ceil(size(CollectCountsNormal.counts, "GB")) + disk_pad

--- a/WGS_pipeline/create_merged_sample.wdl
+++ b/WGS_pipeline/create_merged_sample.wdl
@@ -57,7 +57,7 @@ task create_merged_sample {
         docker: docker
         bootDiskSizeGb: "${boot_disk_size}"
         memory: "${memory} GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }
@@ -110,7 +110,7 @@ task merge_vcfs {
         docker: docker
         bootDiskSizeGb: "${boot_disk_size}"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/WGS_pipeline/fix_mutect2.wdl
+++ b/WGS_pipeline/fix_mutect2.wdl
@@ -61,7 +61,7 @@ task fix_mutect2 {
         docker: docker
         bootDiskSizeGb: "${boot_disk_size}"
         memory: "${memory} GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/WGS_pipeline/guide_mutation_binary.wdl
+++ b/WGS_pipeline/guide_mutation_binary.wdl
@@ -86,7 +86,7 @@ task guide_mutation {
         docker: docker
         bootDiskSizeGb: "${boot_disk_size}"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/WGS_pipeline/liftover.wdl
+++ b/WGS_pipeline/liftover.wdl
@@ -35,7 +35,7 @@ task liftover{
     runtime {
         docker: "${docker}"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/WGS_pipeline/manta_annot.wdl
+++ b/WGS_pipeline/manta_annot.wdl
@@ -68,7 +68,7 @@ task manta_annotator {
         docker: docker_image
         memory: "${mem_size} GB"
         cpu: "${cores}"
-        disks: "local-disk ${disk_size} HDD"
+        disks: "local-disk ${disk_size} SSD"
     }
 
     output {

--- a/WGS_pipeline/mask_variants.wdl
+++ b/WGS_pipeline/mask_variants.wdl
@@ -56,7 +56,7 @@ task bcftools_annotate {
         docker: docker
         bootDiskSizeGb: "${boot_disk_size}"
         memory: "${memory}GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
     }

--- a/WGS_pipeline/msisensor2.wdl
+++ b/WGS_pipeline/msisensor2.wdl
@@ -40,7 +40,7 @@ task msisensor2 {
 	runtime {
 		docker: "davidwu20/msisensor2:1"
 		memory: "${memory}GB"
-		disks: "local-disk ${disk_space} HDD"
+		disks: "local-disk ${disk_space} SSD"
 		cpu: "${num_threads}"
 		preemptible: "${num_preempt}"
 	}

--- a/WGS_pipeline/mutect2_v4.2.6.1.wdl
+++ b/WGS_pipeline/mutect2_v4.2.6.1.wdl
@@ -436,7 +436,7 @@ task SplitIntervals {
         docker: runtime_params.gatk_docker
         bootDiskSizeGb: runtime_params.boot_disk_size
         memory: runtime_params.machine_mem + " MB"
-        disks: "local-disk " + runtime_params.disk + " HDD"
+        disks: "local-disk " + runtime_params.disk + " SSD"
         preemptible: runtime_params.preemptible
         maxRetries: runtime_params.max_retries
         cpu: runtime_params.cpu
@@ -483,7 +483,7 @@ task M2 {
       Int? max_retries
       Int? disk_space
       Int? cpu
-      Boolean use_ssd = false
+      Boolean use_ssd = true
     }
 
     String output_vcf = "output" + if compress then ".vcf.gz" else ".vcf"
@@ -626,7 +626,7 @@ task MergeVCFs {
         docker: runtime_params.gatk_docker
         bootDiskSizeGb: runtime_params.boot_disk_size
         memory: runtime_params.machine_mem + " MB"
-        disks: "local-disk " + runtime_params.disk + " HDD"
+        disks: "local-disk " + runtime_params.disk + " SSD"
         preemptible: runtime_params.preemptible
         maxRetries: runtime_params.max_retries
         cpu: runtime_params.cpu
@@ -670,7 +670,7 @@ task MergeBamOuts {
         docker: runtime_params.gatk_docker
         bootDiskSizeGb: runtime_params.boot_disk_size
         memory: runtime_params.machine_mem + " MB"
-        disks: "local-disk " + select_first([disk_space, runtime_params.disk]) + " HDD"
+        disks: "local-disk " + select_first([disk_space, runtime_params.disk]) + " SSD"
         preemptible: runtime_params.preemptible
         maxRetries: runtime_params.max_retries
         cpu: runtime_params.cpu
@@ -702,7 +702,7 @@ task MergeStats {
         docker: runtime_params.gatk_docker
         bootDiskSizeGb: runtime_params.boot_disk_size
         memory: runtime_params.machine_mem + " MB"
-        disks: "local-disk " + runtime_params.disk + " HDD"
+        disks: "local-disk " + runtime_params.disk + " SSD"
         preemptible: runtime_params.preemptible
         maxRetries: runtime_params.max_retries
         cpu: runtime_params.cpu
@@ -735,7 +735,7 @@ task MergePileupSummaries {
         docker: runtime_params.gatk_docker
         bootDiskSizeGb: runtime_params.boot_disk_size
         memory: runtime_params.machine_mem + " MB"
-        disks: "local-disk " + runtime_params.disk + " HDD"
+        disks: "local-disk " + runtime_params.disk + " SSD"
         preemptible: runtime_params.preemptible
         maxRetries: runtime_params.max_retries
         cpu: runtime_params.cpu
@@ -770,7 +770,7 @@ task LearnReadOrientationModel {
         docker: runtime_params.gatk_docker
         bootDiskSizeGb: runtime_params.boot_disk_size
         memory: machine_mem + " MB"
-        disks: "local-disk " + runtime_params.disk + " HDD"
+        disks: "local-disk " + runtime_params.disk + " SSD"
         preemptible: runtime_params.preemptible
         maxRetries: runtime_params.max_retries
         cpu: runtime_params.cpu
@@ -803,7 +803,7 @@ task CalculateContamination {
         docker: runtime_params.gatk_docker
         bootDiskSizeGb: runtime_params.boot_disk_size
         memory: runtime_params.machine_mem + " MB"
-        disks: "local-disk " + runtime_params.disk + " HDD"
+        disks: "local-disk " + runtime_params.disk + " SSD"
         preemptible: runtime_params.preemptible
         maxRetries: runtime_params.max_retries
         cpu: runtime_params.cpu
@@ -864,7 +864,7 @@ task Filter {
         docker: runtime_params.gatk_docker
         bootDiskSizeGb: runtime_params.boot_disk_size
         memory: runtime_params.machine_mem + " MB"
-        disks: "local-disk " + select_first([disk_space, runtime_params.disk]) + " HDD"
+        disks: "local-disk " + select_first([disk_space, runtime_params.disk]) + " SSD"
         preemptible: runtime_params.preemptible
         maxRetries: runtime_params.max_retries
         cpu: runtime_params.cpu
@@ -930,7 +930,7 @@ task FilterAlignmentArtifacts {
         docker: runtime_params.gatk_docker
         bootDiskSizeGb: runtime_params.boot_disk_size
         memory: machine_mem + " MB"
-        disks: "local-disk " + runtime_params.disk + " HDD"
+        disks: "local-disk " + runtime_params.disk + " SSD"
         preemptible: runtime_params.preemptible
         maxRetries: runtime_params.max_retries
         cpu: runtime_params.cpu
@@ -1064,7 +1064,7 @@ task Funcotate {
         docker: runtime_params.gatk_docker
         bootDiskSizeGb: runtime_params.boot_disk_size
         memory: runtime_params.machine_mem + " MB"
-        disks: "local-disk " + select_first([disk_space, runtime_params.disk]) + " HDD"
+        disks: "local-disk " + select_first([disk_space, runtime_params.disk]) + " SSD"
         preemptible: runtime_params.preemptible
         maxRetries: runtime_params.max_retries
         cpu: runtime_params.cpu

--- a/WGS_pipeline/opencravat.wdl
+++ b/WGS_pipeline/opencravat.wdl
@@ -95,7 +95,7 @@ with open(sys.argv[1],'rb') as f:
         docker: docker
         bootDiskSizeGb: "${boot_disk_size}"
         memory: "${memory} GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
         maxRetries: "${retries}"

--- a/WGS_pipeline/opencravat_cosmic.wdl
+++ b/WGS_pipeline/opencravat_cosmic.wdl
@@ -81,7 +81,7 @@ task opencravat {
         docker: docker
         bootDiskSizeGb: "${boot_disk_size}"
         memory: "${memory} GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
         maxRetries: "${retries}"

--- a/WGS_pipeline/opencravat_dm.wdl
+++ b/WGS_pipeline/opencravat_dm.wdl
@@ -124,7 +124,7 @@ with open(sys.argv[1],'rb') as f:
         docker: docker
         bootDiskSizeGb: "${boot_disk_size}"
         memory: "${memory} GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
         maxRetries: "${retries}"

--- a/WGS_pipeline/opencravat_oncokb.wdl
+++ b/WGS_pipeline/opencravat_oncokb.wdl
@@ -81,7 +81,7 @@ task opencravat {
         docker: docker
         bootDiskSizeGb: "${boot_disk_size}"
         memory: "${memory} GB"
-        disks: "local-disk ${disk_space} HDD"
+        disks: "local-disk ${disk_space} SSD"
         cpu: "${num_threads}"
         preemptible: "${num_preempt}"
         maxRetries: "${retries}"

--- a/WGS_pipeline/remove_filtered.wdl
+++ b/WGS_pipeline/remove_filtered.wdl
@@ -37,7 +37,7 @@ task RemoveFiltered {
     }
 
     runtime {
-        disks: "local-disk 20 HDD"
+        disks: "local-disk 20 SSD"
         memory: "~{mem} GB"
         cpu: cpu
         preemptible: preemptible

--- a/WGS_pipeline/vcf_to_depmap.wdl
+++ b/WGS_pipeline/vcf_to_depmap.wdl
@@ -59,7 +59,7 @@ task vcf_to_depmap {
     }
 
     runtime {
-        disks: "local-disk ~{disk_space} HDD"
+        disks: "local-disk ~{disk_space} SSD"
         memory: "~{mem} GB"
         cpu: cpu
         preemptible: preemptible


### PR DESCRIPTION
No change to any WDL except using SSDs instead of HDDs everywhere inside the `RNA_pipeline` and `WGS_pipeline` folders:

- Hard-coded "HDD" in our WDL is now "SSD".
- WDL imported from Github where a `use_ssd` option was already available as a task input now uses `use_ssd = true` whenever such a task is called.
- WDL imported from Github where HDDs are hard-coded have been forked into [this gist](https://gist.github.com/cds-github-apps/167613785407905d2590ac51b6670895) where the only changes are fixing that thing.