### PR TITLE
Update rna pipeline for crams

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -31,6 +31,7 @@ workflows:
       branches:
         - dev
         - master
+        - update-rna-pipeline-for-crams
   - name: WGS_pipeline
     subclass: WDL
     publish: True

--- a/RNA_pipeline/RNA_pipeline.wdl
+++ b/RNA_pipeline/RNA_pipeline.wdl
@@ -14,6 +14,7 @@ workflow RNA_pipeline {
   #samtofastq_v1
   File input_bam_cram
   File reference_fasta
+  File reference_fasta_index
 
   #star_v1
   File star_index
@@ -61,7 +62,8 @@ workflow RNA_pipeline {
     input:
       input_bam_cram=input_bam_cram,
       prefix=sample_id,
-      reference_fasta=reference_fasta
+      reference_fasta=reference_fasta,
+      reference_index=reference_fasta_index
   }
 
   call star_v1.star as star {

--- a/RNA_pipeline/samtofastq_wdl1-0.wdl
+++ b/RNA_pipeline/samtofastq_wdl1-0.wdl
@@ -52,7 +52,8 @@ workflow samtofastq_workflow {
     input {
         File input_bam_cram
         String prefix
-        File? reference_fasta
+        File reference_fasta
+        File reference_index
 
         Float memory
         Int java_memory = floor(memory - 0.5)
@@ -66,6 +67,7 @@ workflow samtofastq_workflow {
             input_bam_cram = input_bam_cram,
             prefix = prefix,
             reference_fasta = reference_fasta,
+            reference_index = reference_index,
             memory = memory,
             java_memory = java_memory,
             disk_space = disk_space,

--- a/RNA_pipeline/samtofastq_wdl1-0.wdl
+++ b/RNA_pipeline/samtofastq_wdl1-0.wdl
@@ -5,7 +5,8 @@ task samtofastq {
     input {
         File input_bam_cram
         String prefix
-        File? reference_fasta
+        File reference_fasta
+        File reference_index
 
         Float memory = 64
         Int java_memory = floor(memory - 0.5)


### PR DESCRIPTION
Ensure that the samtofastq task localizes the ref index so it can handle cram. The same workflow can be run on both bam and cram