### PR TITLE
update WGS notebook with new sample loading instructions

### DIFF
--- a/WGS_CCLE.ipynb
+++ b/WGS_CCLE.ipynb
@@ -27,12 +27,12 @@
      "evalue": "No module named 'gumbo_client'",
      "output_type": "error",
      "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[2], line 6\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mdepmapomics\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m constants\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mdepmapomics\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m env_config\n\u001b[0;32m----> 6\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mdepmapomics\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m dm_omics\n\u001b[1;32m      7\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mdepmapomics\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m mutations \u001b[38;5;28;01mas\u001b[39;00m omics_mut\n\u001b[1;32m      8\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mdepmapomics\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m copynumbers \u001b[38;5;28;01mas\u001b[39;00m omics_cn\n",
-      "File \u001b[0;32m~/depmap_omics/depmapomics/dm_omics.py:11\u001b[0m\n\u001b[1;32m      7\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mtaigapy\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m TaigaClient\n\u001b[1;32m      9\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mmgenepy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mutils\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m helper \u001b[38;5;28;01mas\u001b[39;00m h\n\u001b[0;32m---> 11\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mdepmap_omics_upload\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m tracker \u001b[38;5;28;01mas\u001b[39;00m track\n\u001b[1;32m     13\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mdepmapomics\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m expressions\n\u001b[1;32m     14\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mdepmapomics\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m mutations\n",
-      "File \u001b[0;32m~/.cache/pypoetry/virtualenvs/depmap-omics-saIjBcuY-py3.9/lib/python3.9/site-packages/depmap_omics_upload/tracker.py:10\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mdalmatian\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mdm\u001b[39;00m\n\u001b[1;32m      9\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01msignal\u001b[39;00m\n\u001b[0;32m---> 10\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mgumbo_client\u001b[39;00m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mgumbo_client\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mutils\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mgumbo_utils\u001b[39;00m\n\u001b[1;32m     12\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mdatetime\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m date\n",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'gumbo_client'"
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mModuleNotFoundError\u001B[0m                       Traceback (most recent call last)",
+      "Cell \u001B[0;32mIn[2], line 6\u001B[0m\n\u001B[1;32m      3\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mdepmapomics\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m constants\n\u001B[1;32m      4\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mdepmapomics\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m env_config\n\u001B[0;32m----> 6\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mdepmapomics\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m dm_omics\n\u001B[1;32m      7\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mdepmapomics\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m mutations \u001B[38;5;28;01mas\u001B[39;00m omics_mut\n\u001B[1;32m      8\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mdepmapomics\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m copynumbers \u001B[38;5;28;01mas\u001B[39;00m omics_cn\n",
+      "File \u001B[0;32m~/depmap_omics/depmapomics/dm_omics.py:11\u001B[0m\n\u001B[1;32m      7\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mtaigapy\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m TaigaClient\n\u001B[1;32m      9\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mmgenepy\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mutils\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m helper \u001B[38;5;28;01mas\u001B[39;00m h\n\u001B[0;32m---> 11\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mdepmap_omics_upload\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m tracker \u001B[38;5;28;01mas\u001B[39;00m track\n\u001B[1;32m     13\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mdepmapomics\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m expressions\n\u001B[1;32m     14\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mdepmapomics\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m mutations\n",
+      "File \u001B[0;32m~/.cache/pypoetry/virtualenvs/depmap-omics-saIjBcuY-py3.9/lib/python3.9/site-packages/depmap_omics_upload/tracker.py:10\u001B[0m\n\u001B[1;32m      8\u001B[0m \u001B[38;5;28;01mimport\u001B[39;00m \u001B[38;5;21;01mdalmatian\u001B[39;00m \u001B[38;5;28;01mas\u001B[39;00m \u001B[38;5;21;01mdm\u001B[39;00m\n\u001B[1;32m      9\u001B[0m \u001B[38;5;28;01mimport\u001B[39;00m \u001B[38;5;21;01msignal\u001B[39;00m\n\u001B[0;32m---> 10\u001B[0m \u001B[38;5;28;01mimport\u001B[39;00m \u001B[38;5;21;01mgumbo_client\u001B[39;00m\n\u001B[1;32m     11\u001B[0m \u001B[38;5;28;01mimport\u001B[39;00m \u001B[38;5;21;01mgumbo_client\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mutils\u001B[39;00m \u001B[38;5;28;01mas\u001B[39;00m \u001B[38;5;21;01mgumbo_utils\u001B[39;00m\n\u001B[1;32m     12\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mdatetime\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m date\n",
+      "\u001B[0;31mModuleNotFoundError\u001B[0m: No module named 'gumbo_client'"
      ]
     }
    ],
@@ -62,113 +62,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "isCCLE = True\n",
-    "doCleanup = False"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Loading new data\n",
-    "\n",
-    "Currently, sequenced data for DepMap is generated by the Genomics Platform (GP) at the Broad who deposits them into several different Terra workspaces. Therefore, the first step of this pipeline is to look at these workspaces and:\n",
-    "\n",
-    " - identify new samples by looking at the bam files and compare them with bams we have already onboarded\n",
-    " - remove duplicates and ones with broken file paths\n",
-    " - map files to profiles in Gumbo, if possible\n",
-    " - onboard new samples and new versions of old cell lines if we find any"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### The following two cells scan the delivery workspaces and add new samples to gumbo. Currently under construction to be regularly run off-cycle"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Currently working on running this step off-cycle\n",
-    "# if isCCLE:\n",
-    "#     print(\"loading new WGS data\")\n",
-    "#     from depmap_omics_upload import loading\n",
-    "#     wgssamples, unmapped = loading.loadFromMultipleWorkspaces(WGSWORKSPACES, EXTRACT_DEFAULTS[\"sm_id\"], \"SMIDOrdered\", \"wgs\", bamcol=\"cram_path\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Currently working on running this step off-cycle\n",
-    "# if isCCLE:\n",
-    "#     from depmap_omics_upload import loading\n",
-    "#     # write samples to Sequencing table, copy bam files to internal storage bucket:\n",
-    "#     wgssamples, cmds = loading.addSamplesToGumbo(wgssamples, 'wgs', WGS_GCS_PATH, filetypes=[\"cram\", \"crai\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### All WGS sequencingIDs in gumbo that are not in the WGS terra workspace yet are considered \"new\" for the current release. Here we add them to the terra processing workspace as a sample set."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if isCCLE:\n",
-    "    from depmap_omics_upload import loading\n",
-    "    # load new rna samples from gumbo to WGS terra workspace:\n",
-    "    loading.addSamplesToDepMapWorkspace('wgs', env_config.WGSWORKSPACE, samplesetname=constants.SAMPLESETNAME, add_to_samplesets=['allcurrent'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Run SNP fingerprinting, new (rna + wgs) vs all existing samples"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wgs_wm = dm.WorkspaceManager(env_config.WGSWORKSPACE)\n",
-    "rna_wm = dm.WorkspaceManager(env_config.RNAWORKSPACE)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wgs_all = wgs_wm.get_sample_sets().loc[constants.SAMPLESETNAME, \"samples\"]\n",
-    "rna_all = rna_wm.get_sample_sets().loc[constants.SAMPLESETNAME, \"samples\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if isCCLE:\n",
-    "    updated_lod_mat, mismatches, matches = await fp._CCLEFingerPrint(rna_all, wgs_all)"
-   ]
+   "source": "isCCLE = True"
   },
   {
    "cell_type": "markdown",
@@ -177,6 +71,16 @@
     "# Run pipeline on Terra\n",
     "\n",
     "We are using Dalmatian to send requests to Terra. See [our readme](https://github.com/broadinstitute/depmap_omics/blob/master/documentation/DepMap_processing_pipeline.md) for detailed breakdown of the subtasks in our WGS pipeline."
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "# Loading new data\n",
+    "\n",
+    "- Sample onboarding is automated in the [dogspa](https://github.com/broadinstitute/dogspa) repo.\n",
+    "- The [omics-wgs-pipeline](https://github.com/broadinstitute/omics-wgs-pipeline) will be where production WGS pipeline code is stored and eventually run using continuous delivery. So far, this only includes the realignment/preprocessing pipeline. The `refresh-legacy-terra-samples` command in that repo will populate the \"legacy\" WGS workspace with new alignment-ready BAMs and other sample data table columns needed for downstream workflows."
    ]
   },
   {
@@ -417,39 +321,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "!cd ../depmap-release-readmes/ && python3 make_new_release.py $constants.RELEASE  && git add . && git commit -m $constants.RELEASE && git push "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### cleaning workspaces"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from depmap_omics_upload.mgenepy import terra as terra_cleanup\n",
-    "from mgenepy.utils import helper as h "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if doCleanup:\n",
-    "    print(\"cleaning workspaces\")\n",
-    "    torm = await terra_cleanup.deleteHeavyFiles(\"broad-firecloud-ccle/DEV_DepMap_WGS_CN\")\n",
-    "    h.parrun(['gsutil rm '+i for i in torm], cores=8)\n",
-    "    terra_cleanup.removeFromFailedWorkflows(\"broad-firecloud-ccle/DEV_DepMap_WGS_CN\", dryrun=False)"
-   ]
+   "source": "!cd ../depmap-release-readmes/ && python3 make_new_release.py $constants.RELEASE  && git add . && git commit -m $constants.RELEASE && git push"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
- Updating sample data table loading instructions: `addSamplesToGumbo` is replaced by a command in another repo that will add unprocessed samples to the workspace like before, but it will now also populate the analysis-ready BAM/BAI URLs. Just let me know when you want me to run it.
- Removing other obsolete information about sample onboarding and workspace cleanup.